### PR TITLE
build-kernel-env-with-nix: pin gcc49Stdenv from nixos-24.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ How to build a gray386linux
 
 Tested build environments:
 
-- Docker/podman container - because gcc4.9stdEnv has been removed, this is only supported way how to build.
+- NixOS 25.11
+- Fedora 44
+- Docker/podman container
 
 **10.** [Install Nix](https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation)
 ----------------------------------------------------------------------------------------------------------------------

--- a/src/build-kernel-env-with-nix/shell.nix
+++ b/src/build-kernel-env-with-nix/shell.nix
@@ -4,10 +4,15 @@ let
   oldPkgs =
     import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/aeaa79dc82980869a88a5955ea3cd3e1944b7d80.tar.gz") { };
 
+  # gcc49Stdenv was retired from nixpkgs (kernel 3.7 only builds with gcc <= 4.9),
+  # so pull it from the last release branch that still ships it: nixos-24.05.
+  gcc49Pkgs =
+    import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b134951a4c9f3c995fd7be05f3243f8ecd65d798.tar.gz") { };
+
   oldPerlPkg = oldPkgs.perl520;
 
 in
-gcc49Stdenv.mkDerivation
+gcc49Pkgs.gcc49Stdenv.mkDerivation
 {
   name = "old-kernel-dev-environment";
   buildInputs = [

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix:2.20.0
+FROM nixos/nix:latest
 MAINTAINER Robin Hack <hack.robin@gmail.com>
 
 WORKDIR /build


### PR DESCRIPTION
Same gcc49Stdenv removal that motivated commit a68763388 (Update docker file for compilation) breaks the direct
`nix-shell src/build-kernel-env-with-nix` flow as well: current nixpkgs no longer ships gcc49Stdenv, so the bare reference at the end of the file resolves to an undefined attribute and the kernel shell can't be entered without going through Docker.

Pin a second nixpkgs branch (nixos-24.05, the last release that still carries gcc49Stdenv) and reach into it for that one derivation.  Everything else in the shell still resolves against the user's `<nixpkgs>` so perl, flex, syslinux, ncurses and friends keep tracking current nixpkgs.

After this change `nix-shell src/build-kernel-env-with-nix` opens cleanly and `make -C src/linux-3.7.10` builds bzImage without needing podman/docker.

Tested:
    nix-shell src/build-kernel-env-with-nix \
        --run 'make -C src/linux-3.7.10 ARCH=i386 -j$(nproc)'